### PR TITLE
Update .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,7 +7,6 @@
 inst/source/Outputs
 inst/checks/*
 inst/source/*
-inst/report/
 inst/source/Library
 inst/source/*Rcheck
 inst/source/*tar.gz


### PR DESCRIPTION
Due to the fact that inst/report is ignore in R build, this folder does not exist when the package is installed:
```r
list.files(system.file(package = "riskreports"))
# [1] "DESCRIPTION" "help"        "html"        "INDEX"       "LICENSE"     "Meta"        "NAMESPACE"   "R"           "WORDLIST"
```

Thus the reporting doesn't work.