### PR TITLE
Add parameter for selecting output format

### DIFF
--- a/R/reporter.R
+++ b/R/reporter.R
@@ -24,6 +24,7 @@ package_report <- function(
     package_version,
     package = NULL,
     template_path = system.file("report/pkg_template.qmd", package = "riskreports"),
+    output_format = "all",
     params = list(),
     ...
 ) {
@@ -90,7 +91,7 @@ package_report <- function(
     suppressMessages({suppressWarnings({
       out <- quarto::quarto_render(
         input = template,
-        output_format = "all",
+        output_format = output_format,
         execute_params = params,
         ...
       )

--- a/R/reporter.R
+++ b/R/reporter.R
@@ -4,6 +4,7 @@
 #' @param package_version Package version number.
 #' @param package Path where to find a package source to retrieve name and version number.
 #' @param template_path Path to a custom quarto template file
+#' @param output_format Output format for the report. Default is "all".
 #' @param params A list of execute parameters passed to the template
 #' @param ... Additional arguments passed to `quarto::quarto_render()`
 #'

--- a/inst/report/pkg_template.qmd
+++ b/inst/report/pkg_template.qmd
@@ -83,7 +83,7 @@ d_riskmetric <- readRDS(risk_path)
 # Assesment produces a data.frame with one row
 r_riskmetric <- riskreports::assessment(d_riskmetric)
 is_na <- sapply(r_riskmetric, function(x){is.na(x) || (is.character(x) && startsWith(x, "no applicable"))})
-knitr::kable(r_riskmetric[, !is_na]) # Use this to have some summary text and report it.
+knitr::kable(t(r_riskmetric[, !is_na])) # Use this to have some summary text and report it.
 # d_riskmetric
 ```
 

--- a/man/package_report.Rd
+++ b/man/package_report.Rd
@@ -9,6 +9,7 @@ package_report(
   package_version,
   package = NULL,
   template_path = system.file("report/pkg_template.qmd", package = "riskreports"),
+  output_format = "all",
   params = list(),
   ...
 )
@@ -21,6 +22,8 @@ package_report(
 \item{package}{Path where to find a package source to retrieve name and version number.}
 
 \item{template_path}{Path to a custom quarto template file}
+
+\item{output_format}{Output format for the report. Default is "all".}
 
 \item{params}{A list of execute parameters passed to the template}
 


### PR DESCRIPTION
## Description
This PR adds the following changes:
- paramterize `output_format` argument. this would be a tremendous speedup to the ci running in pharmapkgs, because for the sake of the repository we only need markdown files, which are later converted to HTML by quarto rendering process.
- transpose metrics table in the report for better page layout