### PR TITLE
Add files to improve the display of licenses information

### DIFF
--- a/R/license_info.R
+++ b/R/license_info.R
@@ -1,0 +1,202 @@
+# Matrix obtained from choose a license
+license_info <- structure(c("BSD Zero Clause License", "Academic Free License v3.0",
+            "GNU Affero General Public License v3.0", "Apache License 2.0",
+            "Artistic License 2.0", "Blue Oak Model License 1.0.0", "BSD-2-Clause Plus Patent License",
+            "BSD 2-Clause \"Simplified\" License", "BSD 3-Clause Clear License",
+            "BSD 3-Clause \"New\" or \"Revised\" License", "BSD 4-Clause \"Original\" or \"Old\" License",
+            "Boost Software License 1.0", "Creative Commons Attribution 4.0 International",
+            "Creative Commons Attribution Share Alike 4.0 International",
+            "Creative Commons Zero v1.0 Universal", "CeCILL Free Software License Agreement v2.1",
+            "CERN Open Hardware Licence Version 2 - Permissive", "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+            "CERN Open Hardware Licence Version 2 - Weakly Reciprocal", "Educational Community License v2.0",
+            "Eclipse Public License 1.0", "Eclipse Public License 2.0", "European Union Public License 1.1",
+            "European Union Public License 1.2", "GNU Free Documentation License v1.3",
+            "GNU General Public License v2.0", "GNU General Public License v3.0",
+            "ISC License", "GNU Lesser General Public License v2.1", "GNU Lesser General Public License v3.0",
+            "LaTeX Project Public License v1.3c", "MIT No Attribution", "MIT License",
+            "Mozilla Public License 2.0", "Microsoft Public License", "Microsoft Reciprocal License",
+            "Mulan Permissive Software License, Version 2", "University of Illinois/NCSA Open Source License",
+            "Open Data Commons Open Database License v1.0", "SIL Open Font License 1.1",
+            "Open Software License 3.0", "PostgreSQL License", "The Unlicense",
+            "Universal Permissive License v1.0", "Vim License", "Do What The F*ck You Want To Public License",
+            "zlib License", "0BSD", "AFL-3.0", "AGPL-3.0", "APACHE-2.0",
+            "ARTISTIC-2.0", "BLUEOAK-1.0.0", "BSD-2-CLAUSE-PATENT", "BSD-2-CLAUSE",
+            "BSD-3-CLAUSE-CLEAR", "BSD-3-CLAUSE", "BSD-4-CLAUSE", "BSL-1.0",
+            "CC-BY-4.0", "CC-BY-SA-4.0", "CC0-1.0", "CECILL-2.1", "CERN-OHL-P-2.0",
+            "CERN-OHL-S-2.0", "CERN-OHL-W-2.0", "ECL-2.0", "EPL-1.0", "EPL-2.0",
+            "EUPL-1.1", "EUPL-1.2", "GFDL-1.3", "GPL-2.0", "GPL-3.0", "ISC",
+            "LGPL-2.1", "LGPL-3.0", "LPPL-1.3C", "MIT-0", "MIT", "MPL-2.0",
+            "MS-PL", "MS-RL", "MULANPSL-2.0", "NCSA", "ODBL-1.0", "OFL-1.1",
+            "OSL-3.0", "POSTGRESQL", "UNLICENSE", "UPL-1.0", "VIM", "WTFPL",
+            "ZLIB", "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", NA, "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", NA, "limitations", NA, NA, NA, "limitations",
+            "limitations", "limitations", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", NA, NA, "permisive", NA, NA, "permisive", NA, NA,
+            NA, "permisive", "permisive", "permisive", "permisive", NA, "limitations",
+            NA, "permisive", NA, NA, "permisive", NA, NA, NA, "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", "permisive", "permisive", "permisive", "permisive",
+            "permisive", NA, NA, "conditions", NA, NA, NA, NA, NA, NA, NA,
+            NA, NA, NA, NA, NA, "conditions", NA, "conditions", "conditions",
+            NA, "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", NA, "conditions", "conditions", "conditions",
+            NA, NA, "conditions", NA, "conditions", NA, NA, "conditions",
+            NA, "conditions", NA, NA, NA, "conditions", NA, NA, NA, "conditions",
+            "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", NA, "conditions", "conditions", "conditions",
+            "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", "conditions", NA, "conditions", "conditions",
+            "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", "conditions", NA, "conditions", "conditions",
+            NA, "conditions", NA, NA, "conditions", NA, NA, NA, NA, NA, NA,
+            NA, NA, NA, NA, NA, NA, "conditions", NA, NA, NA, NA, NA, NA,
+            "conditions", "conditions", NA, NA, NA, NA, NA, NA, NA, NA, NA,
+            NA, NA, NA, NA, NA, NA, NA, "conditions", NA, NA, NA, NA, NA,
+            NA, NA, NA, "conditions", NA, NA, NA, NA, NA, NA, NA, NA, NA,
+            NA, "conditions", NA, "conditions", NA, "conditions", "conditions",
+            NA, "conditions", "conditions", "conditions", "conditions", "conditions",
+            "conditions", "conditions", NA, "conditions", "conditions", NA,
+            NA, NA, "conditions", NA, "conditions", NA, NA, "conditions",
+            "conditions", "conditions", NA, NA, NA, "conditions", NA, NA,
+            NA, "conditions", "conditions", "conditions", "conditions", NA,
+            NA, NA, NA, NA, NA, NA, "conditions", "conditions", NA, NA, "conditions",
+            "conditions", "conditions", "conditions", NA, NA, "conditions",
+            "conditions", "conditions", "conditions", "conditions", NA, "conditions",
+            "conditions", "conditions", NA, NA, NA, NA, NA, NA, NA, NA, NA,
+            "conditions", NA, NA, NA, "conditions", NA, "conditions", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", NA, NA, "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", NA, NA, "limitations", NA, "limitations",
+            NA, "limitations", "limitations", NA, NA, NA, NA, NA, NA, NA,
+            "limitations", "limitations", "limitations", NA, NA, NA, NA,
+            "limitations", NA, NA, "limitations", "limitations", NA, NA,
+            NA, NA, NA, NA, NA, NA, NA, "limitations", "limitations", "limitations",
+            "limitations", NA, "limitations", NA, "limitations", NA, NA,
+            NA, NA, NA, NA, "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", "limitations", "limitations", "limitations", "limitations",
+            "limitations", NA, NA, "limitations", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/",
+            "https://choosealicense.com/appendix/", "https://choosealicense.com/appendix/"
+), dim = c(47L, 16L), dimnames = list(NULL, c("name", "acronym",
+                                              "Commercial use", "Distribution", "Modification", "Patent use",
+                                              "Private use", "Disclose source", "License and copyright notice",
+                                              "Network use is distribution", "Same license", "State changes",
+                                              "Liability", "Trademark use", "Warranty", "url")))
+
+# TODO function for matching R package license information with the table above
+licensing_match <- function(license) {
+  # demo data
+  ap <- available.packages()
+  licenses <- ap[, "License"]
+  out <- gsub( ".? ?file LICENSE|.? ?file LICENCE", "", licenses)
+  if (any(grepl(pattern = "+", out, fixed = TRUE))) {
+    warning("Please report to the package maintainer: the license is not well cleaned.")
+  }
+  s <- strsplit(out, " | ", fixed = TRUE)
+  l <- lapply(s, function(x) {
+    x <- gsub(" (>= ", "-", trimws(x), fixed = TRUE)
+    x <- gsub(" (<= ", "-", x, fixed = TRUE)
+    x <- gsub(" (== ", "-", x, fixed = TRUE)
+    x <- gsub(" (> ", "-", x, fixed = TRUE)
+    x <- gsub(")", "", x, fixed = TRUE)
+
+    k <- (startsWith(x, "GPL") | startsWith(x, "AGPL")) & grepl("-", x, fixed = TRUE) & !endsWith(x, ".0")
+    x[k] <- paste0(x[k], ".0")
+
+    if (any(k <- startsWith(x, "Apache"))) {
+      x[k] <- "APACHE-2.0"
+    }
+    x <- gsub("_", "-", toupper(x), fixed = TRUE)
+    m <- match(x, df$acronym)
+    if (any(k <- is.na(m))) {
+      o <- grep(paste0("^", x[k]), df$acronym)
+      m[k] <- if (length(o) == 0L) NA else o
+    }
+    m
+  })
+  df <- data.frame(license_info, check.names = FALSE)
+
+  match(s[["AER"]], df$acronym)
+}
+
+license_url <- function(license) {
+  df <- data.frame(license_info, check.names = FALSE)
+  df$url[df$acronym == license]
+}
+
+license_table <- function(license) {
+  df <- data.frame(license_info, check.names = FALSE)
+  sub_df <- df[df$acronym == license, -c(1:2, ncol(df))]
+}

--- a/inst/choosealicense.R
+++ b/inst/choosealicense.R
@@ -1,0 +1,33 @@
+# Script to extract a table with the permissions each license allows
+
+library("xml2")
+url <- "https://choosealicense.com/appendix/"
+license_table <- url |>
+  read_html() |>
+  xml_find_all("//table")
+
+cols <- license_table |>
+  xml_find_all("//th[@scope='col']/a") |>
+  xml_text()
+
+rows <- license_table |>
+  xml_find_all("//th[@scope='row']/a") |>
+  xml_text()
+
+licenses_url <- license_table |>
+  xml_find_all("//th[@scope='row']/a") |>
+  xml_attr("href")
+acronym <- licenses_url |>
+  basename() |>
+  toupper()
+
+
+
+legend <- license_table |> xml_find_all("//td") |> xml_attr("class")
+legend <- gsub("license-", replacement = "", x = legend, fixed = TRUE)
+legend[legend == "permissions"] <- "permisive"
+dim(legend) <- c(length(cols), length(rows))
+rownames(legend) <- cols
+legendary <- t(legend)
+df <- cbind(name = rows, acronym = acronym, legendary, url = url)
+View(df)


### PR DESCRIPTION
The inst/choosealicense.R provides scripts to extract the table of their appendix.
The file Rlicense_info.R provides scripts to match and help with license information. 

This is related to #24 