### PR TITLE
add check for r_cmd_check

### DIFF
--- a/inst/report/package/pkg_template.qmd
+++ b/inst/report/package/pkg_template.qmd
@@ -75,6 +75,11 @@ The following metrics are derived from the `riskmetric` R package.
 
 ```{r read-riskmetric, warning=FALSE}
 d_riskmetric <- readRDS(risk_path)
+
+# Ensure r_cmd_check exists to avoid errors
+if (!"r_cmd_check" %in% names(d_riskmetric)) {
+  d_riskmetric[["r_cmd_check"]] <- structure(NA, class = "risk_metric_error")
+}
 ```
 
 ```{r create_r_riskmetric, warning=FALSE}


### PR DESCRIPTION
This PR ensures that the `r_cmd_check` field is present in the `d_riskmetric` object loaded from the assessment .rds file, even if it was not part of the original risk assessment output. This prevents `d_riskmetric[["r_cmd_check"]]` from throwing an error during report rendering.