### PR TITLE
add checks for required fields

### DIFF
--- a/inst/report/package/pkg_template.qmd
+++ b/inst/report/package/pkg_template.qmd
@@ -75,6 +75,16 @@ The following metrics are derived from the `riskmetric` R package.
 
 ```{r read-riskmetric, warning=FALSE}
 d_riskmetric <- readRDS(risk_path)
+
+# Required fields
+required_fields <- c("r_cmd_check", "license", "remote_checks", "covr_coverage")
+
+# Assign default error structure for missing fields to avoid errors
+for (field in required_fields) {
+  if (!field %in% names(d_riskmetric)) {
+    d_riskmetric[[field]] <- structure(NA, class = "risk_metric_error")
+  }
+}
 ```
 
 ```{r create_r_riskmetric, warning=FALSE}


### PR DESCRIPTION
This PR ensures that the `d_riskmetric` object contains a consistent set of required fields by assigning a default `risk_metric_error` structure to any missing entries. This prevents downstream errors due to missing metrics when rendering report.